### PR TITLE
Fix: typo in devlog head

### DIFF
--- a/devlog/index.html
+++ b/devlog/index.html
@@ -10,7 +10,7 @@
         <meta name="description" content="HiddenArcade - free web games from an indie developer">
         <meta name="keywords" content="hidden arcade, free games, web arcade, online arcade, web games, javascript games">
         <meta name="author" content="Louis Savoie">
-        <link rel="canonical" href="https://www.hiddenarcade.net/devlog/index.html">www.
+        <link rel="canonical" href="https://www.hiddenarcade.net/devlog/index.html">
 
         <!-- Open Graph -->
         <meta property="og:type" content="website">


### PR DESCRIPTION
somehow i added "www." to the devlog head outside the tags.