### PR TITLE
Fix: pickaxe mining twice per click

### DIFF
--- a/minecart/game.js
+++ b/minecart/game.js
@@ -210,10 +210,6 @@ pickaxeImg.addEventListener('mouseup', () => {
     runPickaxe()
 })
 
-pickaxeImg.addEventListener('touchend', () => {
-    runPickaxe()
-})
-
 resetButton.addEventListener('click', () => {
     resetGame()
 })


### PR DESCRIPTION
The touch event listeners cause the pick logic to run twice. The guilty event listener was deleted without sacrificing the animation it was meant to implement. It seems only touchstart is required.