### PR TITLE
Fixes: iPhone button text color and zoom on click

### DIFF
--- a/minecart/game.css
+++ b/minecart/game.css
@@ -17,6 +17,7 @@ button {
     background-color: rgb(189, 189, 189);
     font-family: 'Bebas Neue', sans-serif;
     font-size: 1rem;
+    color: black;
 }
 
 h2 {
@@ -67,6 +68,17 @@ h2 {
 
 #pickaxe-img {
     margin: 0 0 .5rem 0;
+    height: 150px;
+    width: 150px;
+    background-color: #25252a;
+}
+
+.pickaxe1 {
+    background-image: url("img/pickaxe1.png");
+}
+
+.pickaxe2 {
+    background-image: url("img/pickaxe2.png");
 }
 
 input {

--- a/minecart/game.js
+++ b/minecart/game.js
@@ -107,7 +107,7 @@ function setupDisplays() {
 }
 
 function runPickaxe() {
-    pickaxeImg.src = 'img/pickaxe1.png'
+    pickaxeImg.classList = 'pickaxe1'
     if (!pickActive) return
     const block = mine()
     updateLootDisplay(block)
@@ -199,11 +199,11 @@ function resetScores() {
 
 // Event Listeners
 pickaxeImg.addEventListener('mousedown', () => {
-    pickaxeImg.src = 'img/pickaxe2.png'
+    pickaxeImg.classList = 'pickaxe2'
 })
 
 pickaxeImg.addEventListener('touchstart', () => {
-    pickaxeImg.src = 'img/pickaxe2.png'
+    pickaxeImg.classList = 'pickaxe2'
 })
 
 pickaxeImg.addEventListener('mouseup', () => {

--- a/minecart/index.html
+++ b/minecart/index.html
@@ -77,7 +77,7 @@
                 <strong><span>SCORE: <span id="score-display">0</span></span></strong>
             </div>
 
-            <img id="pickaxe-img" src="img/pickaxe1.png" alt="Pickaxe">
+            <button id="pickaxe-img" class="pickaxe1"></button>
 
             <input type="text" id="initials" placeholder="Initials, max: 4" maxlength="4">
 


### PR DESCRIPTION
On iPhone button text, that was left unspeciified, rendered blue. Also, clicking the pickaxe-img element too rapidly caused the screen to zoom in.

Hopefull solutions:
Changes button text color to black. Changes #pickaxe-img element from img to button, adds pickaxe1 and pickaxe2 classes to css to change button background-image.