### PR TITLE
Feature: Minecart: Keyboard controls

### DIFF
--- a/devlog/index.html
+++ b/devlog/index.html
@@ -35,7 +35,7 @@
         <link rel="apple-touch-icon" sizes="180x180" href="https://www.hiddenarcade.net/favicon/apple-touch-icon.png">
         <link rel="icon" type="image/png" sizes="32x32" href="https://www.hiddenarcade.net/favicon/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="https://www.hiddenarcade.net/favicon/favicon-16x16.png">
-        <link rel="manifest" href="https://www.hiddenarcade.net/site.webmanifest">
+        <link rel="manifest" href="https://www.hiddenarcade.net/manifest.json">
 
         <!-- Google Fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -77,10 +77,12 @@
                 <p>Currently they are tracked locally in your browser just like the scores and there is a reset button if you want to start over.</p>
                 <p>Also, I went digging thru my old files and found the code for the original version of <a href="/minecart">Minecart</a>. I fixed it up just enough so it would work with the arcade without changing the game itself and now you can play <a href="/minecart-classic">Minecart Classic</a>!</p>
                 <p>There is a link to it at the bottom of <a href="/minecart">Minecart</a> in the new info section I also added.</p>
+                <p>Oh, oh, and one last thing! I just added keyboard controls so you don't have to destroy your mouse button switches ;)</p>
                 <h4>Changes</h4>
                 <ul>
                     <li>Added 7 achievements to <a href="/minecart">Minecart</a>!</li>
                     <li>Added an info section with History to <a href="/minecart">Minecart</a>!</li>
+                    <li>Added keyboard controls to <a href="/minecart">Minecart</a>!</li>
                     <li>New (old) game <a href="/minecart-classic">Minecart Classic</a>!</li>
                 </ul>
             </article>

--- a/minecart/game.js
+++ b/minecart/game.js
@@ -184,6 +184,7 @@ function buildAchievement(achievement) {
 
 function runPickaxe() {
     pickaxeImg.classList = 'pickaxe1'
+    if (!currentAchievements.keepMining.unlocked && !pickActive) runKeepMiningAchievement()
     if (!pickActive) return
     const block = mine()
     updateLootDisplay(block)
@@ -367,7 +368,6 @@ pickaxeImg.addEventListener('touchstart', () => {
 
 pickaxeImg.addEventListener('mouseup', () => {
     runPickaxe()
-    if (!currentAchievements.keepMining.unlocked && !pickActive) runKeepMiningAchievement()
 })
 
 resetButton.addEventListener('click', () => {
@@ -384,4 +384,17 @@ resetAchievementsButton.addEventListener('click', () => {
 
 achievementUnlockedDisplay.addEventListener('click', () => {
     achievementUnlockedDisplay.classList = 'hidden'
+})
+
+document.addEventListener('keydown', (event) => {
+    if (event.target.localName === 'input') return
+    if (event.key === 't') pickaxeImg.classList = 'pickaxe2'
+})
+
+document.addEventListener('keyup', (event) => {
+    if (event.target.localName === 'input') return
+    if (event.key === 't') {
+        runPickaxe()
+    }
+    if (event.key === 'r') resetGame()
 })

--- a/minecart/index.html
+++ b/minecart/index.html
@@ -81,7 +81,7 @@
 
             <input type="text" id="initials" placeholder="Initials, max: 4" maxlength="4">
 
-            <p id="how-to-play"><strong>How to play:</strong> Enter your initials for highscores in the input above then click the pickaxe to mine. The goal is to fill up the minecart without overfilling it. Each ore has a score value based on it's rarity. If you win, your score will be added to the highscores below. Highscores are local to your browser.</p>
+            <p id="how-to-play"><strong>How to play:</strong> Enter your initials for highscores in the input above then click the pickaxe to mine. The goal is to fill up the minecart without overfilling it. Each ore has a score value based on it's rarity. If you win, your score will be added to the highscores below. Highscores are local to your browser.<br><strong>Keyboard Controls:</strong> 'T' = Pickaxe, 'R' = Reset</p>
 
             <h3>Local Highscores</h3>
 


### PR DESCRIPTION
**Changes:**
- Adds keyboard controls to Minecart.
  - T = Pickaxe (cuz it looks like one lol)
  - R = reset (and it's next to T! even on Dvorak, sorry everyone else (insert joke about Colemak 'wasd' being 'wars' which I don't support.))
- Update today's Devlog post
- Updates How to play section