### PR TITLE
Change: Site: Remove Minecart Classic from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,8 +80,7 @@
             <section id="luck">
                 <h3>Luck</h3>
                 <ul>
-                    <li><a href="/minecart">Minecart</a></li>
-                    <li><a href="/minecart-classic/">Minecart Classic</a></li>
+                    <li><a href="/minecart/">Minecart</a></li>
                 </ul>
             </section>
             


### PR DESCRIPTION
Removes Minecart Classic from homepage to prevent confusion with new users thinking it's a good game they should play instead of Minecart.